### PR TITLE
typo in requirements

### DIFF
--- a/requirements-pgsql.txt
+++ b/requirements-pgsql.txt
@@ -20,4 +20,4 @@ wsgiref==0.1.2
 keepassdb==0.2.1
 db_backup==0.1.2
 boto==2.26.1
-lxml=3.3.3
+lxml==3.3.3


### PR DESCRIPTION
requires a '==' instead of a single '=' otherwise you get a pip error
along the lines of:
ValueError: ('Expected version spec in', 'lxml=3.3.3', 'at', '=3.3.3')
