### PR TITLE
Password generator: Make shuffling unbiased

### DIFF
--- a/ratticweb/static/rattic/js/newcore.js
+++ b/ratticweb/static/rattic/js/newcore.js
@@ -372,7 +372,7 @@ var RATTIC = (function ($, ZeroClipboard) {
         // Shuffle the password
         pass = pass.split("");
         for (var x = 0; x < pass.length; x++) {
-            var num = Math.abs(sjcl.random.randomWords(1)[0] % pass.length);
+            var num = x + Math.abs(sjcl.random.randomWords(1)[0] % (pass.length - x));
             var tmp = pass[num];
             pass[num] = pass[x];
             pass[x] = tmp;


### PR DESCRIPTION
The shuffling algorithm did not give all permutations with equal probability. For example, if you called

```
_makePassword(3,['spaces'],['numbers','lcasealpha']);
```

then the space character would be significantly more likely to be the second character than the first character.

I think this fixes it. See http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm .
