### PR TITLE
Turn Group names in profile page into links to list-by-group

### DIFF
--- a/account/templates/account_profile.html
+++ b/account/templates/account_profile.html
@@ -22,7 +22,7 @@
 
 {% endif %}
 <tr><th>{% trans "Last Password Change" %}</th><td>{{ user.profile.password_changed }}</td></tr>
-<tr><th>{% trans "Groups" %}</th><td>{% for g in user.groups.all %}{{ g.name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td></tr>
+<tr><th>{% trans "Groups" %}</th><td>{% for g in user.groups.all %}<a href="{% url "cred.views.list" "group" g.id %}">{{ g.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</td></tr>
 {% for field in form %}
 <tr><th>{{ field.label }}</th><td>{{ field }}</td></tr>
 {% endfor %}


### PR DESCRIPTION
This update changes the behaviour of the listing of groups in a users profile page.

Instead of listing these as plain text, the group names are displayed as links.  Upon clicking a link a listing of passwords within this group are displayed using cred/list-by-group. 

Manually tested in my local Vagrant environment.
