### PR TITLE
No password expiry for oauth

### DIFF
--- a/ratticweb/settings.py
+++ b/ratticweb/settings.py
@@ -272,13 +272,6 @@ if confget('ratticweb', 'ssl_header', False):
 # Setup the loglevel
 LOGGING['loggers']['django.request']['level'] = config.get('ratticweb', 'loglevel')
 
-try:
-    PASSWORD_EXPIRY = timedelta(days=int(config.get('ratticweb', 'passwordexpirydays')))
-except NoOptionError:
-    PASSWORD_EXPIRY = False
-except ValueError:
-    PASSWORD_EXPIRY = False
-
 # [filepaths]
 HELP_SYSTEM_FILES = confget('filepaths', 'help', False)
 MEDIA_ROOT = confget('filepaths', 'media', '')
@@ -397,3 +390,14 @@ if GOAUTH2_ENABLED:
     ]
 
     SESSION_SERIALIZER='django.contrib.sessions.serializers.PickleSerializer'
+
+# Passwords expiry settings
+if GOAUTH2_ENABLED:
+    PASSWORD_EXPIRY = False
+else:
+    try:
+        PASSWORD_EXPIRY = timedelta(days=int(config.get('ratticweb', 'passwordexpirydays')))
+    except NoOptionError:
+        PASSWORD_EXPIRY = False
+    except ValueError:
+        PASSWORD_EXPIRY = False


### PR DESCRIPTION
Hi

This is a bug fix PR for oauth.

Rattic requires passwords to be changed after the default expiry period of 90 days, which is not compatible with oauth.

