### PR TITLE
Making /cred/detail/<cred_id>/fingerprint not visible by default

### DIFF
--- a/conf/defaults.cfg
+++ b/conf/defaults.cfg
@@ -48,6 +48,10 @@ max_attachment_size = 2097152
 #ssl_header=
 #ssl_header_value=
 
+# Set to true to make /cred/detail/<cred_id>/fingerprint
+# not require a login.
+loginless_ssh_fingerprints = false
+
 [filepaths]
 # The on disk location of media files (does nothing right now).
 media =

--- a/ratticweb/settings.py
+++ b/ratticweb/settings.py
@@ -265,6 +265,7 @@ ALLOWED_HOSTS = [config.get('ratticweb', 'hostname'), 'localhost']
 HOSTNAME = config.get('ratticweb', 'hostname')
 RATTIC_MAX_ATTACHMENT_SIZE = int(config.get('ratticweb', 'max_attachment_size'))
 RATTIC_DISABLE_EXPORT = config.getboolean('ratticweb', 'disable_export')
+LOGINLESS_SSH_FINGERPRINTS = config.getboolean("ratticweb", "loginless_ssh_fingerprints")
 
 # Allow SSL termination outside RatticDB
 if confget('ratticweb', 'ssl_header', False):


### PR DESCRIPTION
As discussed with @smarthall, here is the code to make the fingerprint url not on by default.

To make the fingerprint url visible without a login, set the

     [ratticweb]
     loginless_ssh_fingerprints = true