### PR TITLE
Enable SESSION_COOKIE_AGE config variable

### DIFF
--- a/conf/defaults.cfg
+++ b/conf/defaults.cfg
@@ -52,6 +52,9 @@ max_attachment_size = 2097152
 # not require a login.
 loginless_ssh_fingerprints = false
 
+# Set cookietimeout in seconds.
+session_age = 1800
+
 [filepaths]
 # The on disk location of media files (does nothing right now).
 media =

--- a/conf/defaults.cfg
+++ b/conf/defaults.cfg
@@ -52,7 +52,7 @@ max_attachment_size = 2097152
 # not require a login.
 loginless_ssh_fingerprints = false
 
-# Set cookietimeout in seconds.
+# Set session cookie age (timeout) in seconds.
 session_cookie_age = 1800
 
 [filepaths]

--- a/conf/defaults.cfg
+++ b/conf/defaults.cfg
@@ -53,7 +53,7 @@ max_attachment_size = 2097152
 loginless_ssh_fingerprints = false
 
 # Set cookietimeout in seconds.
-session_age = 1800
+session_cookie_age = 1800
 
 [filepaths]
 # The on disk location of media files (does nothing right now).

--- a/ratticweb/settings.py
+++ b/ratticweb/settings.py
@@ -233,6 +233,7 @@ LOGIN_URL = RATTIC_ROOT_URL
 # django-user-sessions
 SESSION_ENGINE = 'user_sessions.backends.db'
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+SESSION_COOKIE_AGE = int(config.get('ratticweb', 'session_age'))
 
 # Icon configuration
 CRED_ICON_JSON = 'db/icons.json'

--- a/ratticweb/settings.py
+++ b/ratticweb/settings.py
@@ -233,7 +233,7 @@ LOGIN_URL = RATTIC_ROOT_URL
 # django-user-sessions
 SESSION_ENGINE = 'user_sessions.backends.db'
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-SESSION_COOKIE_AGE = int(config.get('ratticweb', 'session_age'))
+SESSION_COOKIE_AGE = int(config.get('ratticweb', 'session_cookie_age'))
 
 # Icon configuration
 CRED_ICON_JSON = 'db/icons.json'


### PR DESCRIPTION
Hi,

Since django sessions age defaults to 2 weeks, I needed a way to change this within RatticWeb

I was unsure if it would be better to create a [sessions] section within defaults.cfg, so I opted to put the variable in ratticweb.

I think 30 minutes is a sane default.

I've tested it and it works as expected.

It addresses the following issue: https://github.com/tildaslash/RatticWeb/issues/329

Please review.

Br,
Rasmus