### PR TITLE
Fix kombu and django-celery versions for django 1.6

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -22,7 +22,8 @@ db_backup==0.1.3
 boto==2.26.1
 lxml==3.3.3
 celery>=3.1,<3.2
-django-celery>=3.1,<3.2
+django-celery>=3.1,<3.1.17
 importlib
 django-social-auth>=0.7.9
 paramiko==1.15.2
+kombu==3.0.26


### PR DESCRIPTION
Kombu 3.0.26 and django-celery 3.1.16 are the last verisons that work with django 1.6 it seems

Resolves issue #405 
