### PR TITLE
Focus the username box to save a click

### DIFF
--- a/ratticweb/static/rattic/js/newcore.js
+++ b/ratticweb/static/rattic/js/newcore.js
@@ -778,5 +778,8 @@ $(document).ready(function () {
 
   // Start collecting random numbers
   sjcl.random.startCollectors();
+
+  // Focus the id_username box because if it's on the page, we probably want to log in
+  $("#id_username").focus();
 });
 


### PR DESCRIPTION
If the user isn't logged in already, focus the id_username box because that's probably the first thing they want to do.

It's a very small change but it does make logging into Rattic ever so slightly more convenient.
