### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you decide to use RatticWeb you should take the following into account:
 * The filesystem in which the database is stored should be protected with encryption.
 * The access logs should be protected.
 * The machine which serves RatticWeb should be protected from access.
-* Tools like <a href=="http://www.ossec.net/">OSSEC</a> are your friend.
+* Tools like <a href="http://www.ossec.net/">OSSEC</a> are your friend.
 
 Support and Known Issues:
 * Through <a href="http://twitter.com/RatticDB">twitter</a> or <a href="https://github.com/tildaslash/RatticWeb/issues?state=open">Github Issues</a>


### PR DESCRIPTION
Without this commit, the rendering of README.md is wrong with the link of OSSEC.